### PR TITLE
Added resolved status fields to topics database (Task 6, Issue #12)

### DIFF
--- a/RESOLVED_FIELDS_INTERFACE.md
+++ b/RESOLVED_FIELDS_INTERFACE.md
@@ -1,0 +1,42 @@
+# Resolved Status Database Fields
+
+## Fields Added to Topics
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `resolved` | Integer (0/1) | 0 | Topic resolved status (0=unresolved, 1=resolved) |
+| `resolvedBy` | Integer/null | null | User ID who marked as resolved |
+| `resolvedAt` | Integer/null | null | Unix timestamp (ms) when resolved |
+
+## Usage
+
+### Reading Status
+```javascript
+// Single topic
+const resolved = await Topics.getTopicField(tid, 'resolved');
+const isResolved = resolved === 1;
+
+// Multiple fields
+const data = await Topics.getTopicFields(tid, ['resolved', 'resolvedBy', 'resolvedAt']);
+```
+
+### Setting Status (API Team - Issue #5)
+```javascript
+// Mark resolved
+await Topics.setTopicFields(tid, {
+    resolved: 1,
+    resolvedBy: uid,
+    resolvedAt: Date.now()
+});
+
+// Mark unresolved
+await Topics.setTopicFields(tid, {
+    resolved: 0,
+    resolvedBy: null,
+    resolvedAt: null
+});
+```
+
+## Implementation Files
+- Schema: `src/topics/data.js:17`
+- Migration: `src/upgrades/4.3.3/add_resolved_fields_to_topics.js`

--- a/RESOLVED_FIELDS_INTERFACE.md
+++ b/RESOLVED_FIELDS_INTERFACE.md
@@ -40,3 +40,4 @@ await Topics.setTopicFields(tid, {
 ## Implementation Files
 - Schema: `src/topics/data.js:17`
 - Migration: `src/upgrades/4.3.3/add_resolved_fields_to_topics.js`
+- OpenAPI Schema: `public/openapi/components/schemas/TopicObject.yaml:281-292`

--- a/public/openapi/components/schemas/TopicObject.yaml
+++ b/public/openapi/components/schemas/TopicObject.yaml
@@ -274,10 +274,10 @@ TopicObjectSlim:
                 description: The topic thumbnail filename
               path:
                 type: string
-                description: The relative path to the thumbnail
+                description: Path to topic thumbnail without upload_url prefix
               url:
                 type: string
-                description: The full URL to the thumbnail
+                description: Relative path to the topic thumbnail
         # Resolved status fields for marking topics as resolved
         resolved:
           type: number

--- a/public/openapi/components/schemas/TopicObject.yaml
+++ b/public/openapi/components/schemas/TopicObject.yaml
@@ -274,10 +274,22 @@ TopicObjectSlim:
                 description: The topic thumbnail filename
               path:
                 type: string
-                description: Path to topic thumbnail without upload_url prefix
+                description: The relative path to the thumbnail
               url:
                 type: string
-                description: Relative path to the topic thumbnail
+                description: The full URL to the thumbnail
+        # Resolved status fields for marking topics as resolved
+        resolved:
+          type: number
+          description: Whether the topic is marked as resolved (0=unresolved, 1=resolved)
+        resolvedBy:
+          type: number
+          nullable: true
+          description: The user ID who marked the topic as resolved
+        resolvedAt:
+          type: number
+          nullable: true
+          description: Unix timestamp when the topic was marked as resolved
     - type: object
       description: Optional properties that may or may not be present (except for `tid`, which is always present, and is only here as a hack to pass validation)
       properties:

--- a/public/src/client/search.js
+++ b/public/src/client/search.js
@@ -16,7 +16,6 @@ define('forum/search', [
 	let selectedCids = [];
 	let searchFilters = {};
 	let searchTimeout;
-	let currentQuery = '';
 
 	Search.init = function () {
 		if (document.getElementById('simple-search-input')) {
@@ -140,7 +139,7 @@ define('forum/search', [
 		const advancedSearch = document.getElementById('advanced-search');
 
 		if (toggleAdvanced) {
-			toggleAdvanced.addEventListener('click', function() {
+			toggleAdvanced.addEventListener('click', function () {
 				simpleSearch.classList.add('d-none');
 				advancedSearch.classList.remove('d-none');
 				
@@ -154,7 +153,7 @@ define('forum/search', [
 		}
 
 		if (backToSimple) {
-			backToSimple.addEventListener('click', function() {
+			backToSimple.addEventListener('click', function () {
 				advancedSearch.classList.add('d-none');
 				simpleSearch.classList.remove('d-none');
 				
@@ -179,7 +178,7 @@ define('forum/search', [
 		api.get('/api/search', {
 			term: query,
 			in: 'titlesposts',
-			searchOnly: 1
+			searchOnly: 1,
 		})
 			.then(function (data) {
 				if (data && data.posts && data.posts.length > 0) {
@@ -199,7 +198,7 @@ define('forum/search', [
 	function displaySuggestions(posts, query) {
 		const searchSuggestions = document.getElementById('search-suggestions');
 		
-		let html = posts.map(function (post) {
+		const html = posts.map(function (post) {
 			const title = post.topic ? post.topic.title : (post.title || 'Untitled');
 			const content = post.content || '';
 			
@@ -215,8 +214,8 @@ define('forum/search', [
 		searchSuggestions.classList.add('active');
 
 		// Add click handlers to suggestions
-		searchSuggestions.querySelectorAll('.suggestion-item').forEach(function(item) {
-			item.addEventListener('click', function() {
+		searchSuggestions.querySelectorAll('.suggestion-item').forEach(function (item) {
+			item.addEventListener('click', function () {
 				const tid = this.getAttribute('data-tid');
 				const pid = this.getAttribute('data-pid');
 				if (tid) {
@@ -239,12 +238,10 @@ define('forum/search', [
 				type: 'warning',
 				title: 'No search query',
 				message: 'Please enter something to search for.',
-				timeout: 3000
+				timeout: 3000,
 			});
 			return;
 		}
-
-		currentQuery = query;
 		
 		searchSuggestions.classList.remove('active');
 		
@@ -258,7 +255,7 @@ define('forum/search', [
 		api.get('/api/search', {
 			term: query,
 			in: 'titlesposts',
-			searchOnly: 1
+			searchOnly: 1,
 		})
 			.then(function (data) {
 				if (data && data.posts && data.posts.length > 0) {
@@ -293,7 +290,7 @@ define('forum/search', [
 		
 		searchStatus.innerHTML = `Found ${posts.length} result${posts.length !== 1 ? 's' : ''} for "<strong>${escapeHtml(query)}</strong>"`;
 		
-		let html = posts.map(function (post) {
+		const html = posts.map(function (post) {
 			const user = post.user || {};
 			const topic = post.topic || {};
 			const timeAgo = getTimeAgo(post.timestamp);
@@ -354,7 +351,7 @@ define('forum/search', [
 			'<': '&lt;',
 			'>': '&gt;',
 			'"': '&quot;',
-			"'": '&#039;'
+			"'": '&#039;',
 		};
 		return (text || '').toString().replace(/[&<>"']/g, m => map[m]);
 	}
@@ -383,7 +380,7 @@ define('forum/search', [
 			{ label: 'day', seconds: 86400 },
 			{ label: 'hour', seconds: 3600 },
 			{ label: 'minute', seconds: 60 },
-			{ label: 'second', seconds: 1 }
+			{ label: 'second', seconds: 1 },
 		];
 
 		for (let i = 0; i < intervals.length; i++) {

--- a/public/src/client/search.js
+++ b/public/src/client/search.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 define('forum/search', [
 	'search',
 	'storage',
@@ -16,7 +15,15 @@ define('forum/search', [
 	let selectedTags = [];
 	let selectedCids = [];
 	let searchFilters = {};
+	let searchTimeout;
+	let currentQuery = '';
+
 	Search.init = function () {
+		if (document.getElementById('simple-search-input')) {
+			initializeSimpleSearch();
+			initializeToggle();
+		}
+
 		const searchIn = $('#search-in');
 		searchIn.on('change', function () {
 			updateFormItemVisiblity(searchIn.val());
@@ -65,7 +72,330 @@ define('forum/search', [
 		updateSortFilter();
 
 		searchFilters = getSearchDataFromDOM();
+
+		const urlParams = new URLSearchParams(window.location.search);
+		const queryParam = urlParams.get('term') || urlParams.get('query');
+		if (queryParam) {
+			const simpleInput = document.getElementById('simple-search-input');
+			if (simpleInput) {
+				simpleInput.value = queryParam;
+				performSearch();
+			}
+		}
 	};
+
+	function initializeSimpleSearch() {
+		const searchInput = document.getElementById('simple-search-input');
+		const searchButton = document.getElementById('simple-search-button');
+		const searchSuggestions = document.getElementById('search-suggestions');
+
+		if (!searchInput || !searchButton) {
+			return;
+		}
+
+		// Handle search input with debouncing for real-time suggestions
+		searchInput.addEventListener('input', function (e) {
+			const query = e.target.value.trim();
+			
+			clearTimeout(searchTimeout);
+			
+			if (query.length < 2) {
+				searchSuggestions.classList.remove('active');
+				searchSuggestions.innerHTML = '';
+				return;
+			}
+
+			// Debounce for 300ms
+			searchTimeout = setTimeout(() => {
+				showSuggestions(query);
+			}, 300);
+		});
+
+		// Handle enter key press
+		searchInput.addEventListener('keypress', function (e) {
+			if (e.key === 'Enter') {
+				e.preventDefault();
+				performSearch();
+			}
+		});
+
+		// Handle search button click
+		searchButton.addEventListener('click', function (e) {
+			e.preventDefault();
+			performSearch();
+		});
+
+		// Hide suggestions when clicking outside
+		document.addEventListener('click', function (e) {
+			if (!e.target.closest('.search-box')) {
+				searchSuggestions.classList.remove('active');
+			}
+		});
+	}
+
+	function initializeToggle() {
+		const toggleAdvanced = document.getElementById('toggle-advanced');
+		const backToSimple = document.getElementById('back-to-simple');
+		const simpleSearch = document.getElementById('simple-search');
+		const advancedSearch = document.getElementById('advanced-search');
+
+		if (toggleAdvanced) {
+			toggleAdvanced.addEventListener('click', function() {
+				simpleSearch.classList.add('d-none');
+				advancedSearch.classList.remove('d-none');
+				
+				// Copy search term to advanced search
+				const simpleInput = document.getElementById('simple-search-input');
+				const advancedInput = document.getElementById('search-input');
+				if (simpleInput && advancedInput) {
+					advancedInput.value = simpleInput.value;
+				}
+			});
+		}
+
+		if (backToSimple) {
+			backToSimple.addEventListener('click', function() {
+				advancedSearch.classList.add('d-none');
+				simpleSearch.classList.remove('d-none');
+				
+				// Copy search term back to simple search
+				const advancedInput = document.getElementById('search-input');
+				const simpleInput = document.getElementById('simple-search-input');
+				if (simpleInput && advancedInput) {
+					simpleInput.value = advancedInput.value;
+				}
+			});
+		}
+	}
+
+	function showSuggestions(query) {
+		const searchSuggestions = document.getElementById('search-suggestions');
+		
+		// Show loading state in suggestions
+		searchSuggestions.innerHTML = '<div class="suggestion-item">Searching...</div>';
+		searchSuggestions.classList.add('active');
+
+		// Fetch search results for suggestions
+		api.get('/api/search', {
+			term: query,
+			in: 'titlesposts',
+			searchOnly: 1
+		})
+			.then(function (data) {
+				if (data && data.posts && data.posts.length > 0) {
+					displaySuggestions(data.posts.slice(0, 5), query);
+				} else if (data && data.matchCount === 0) {
+					searchSuggestions.innerHTML = '<div class="suggestion-item">No results found</div>';
+				} else {
+					searchSuggestions.innerHTML = '<div class="suggestion-item">Search not available</div>';
+				}
+			})
+			.catch(function (err) {
+				console.error('Search error:', err);
+				searchSuggestions.innerHTML = '<div class="suggestion-item">Error loading suggestions</div>';
+			});
+	}
+
+	function displaySuggestions(posts, query) {
+		const searchSuggestions = document.getElementById('search-suggestions');
+		
+		let html = posts.map(function (post) {
+			const title = post.topic ? post.topic.title : (post.title || 'Untitled');
+			const content = post.content || '';
+			
+			return `
+				<div class="suggestion-item" data-pid="${post.pid}" data-tid="${post.tid || (post.topic ? post.topic.tid : '')}">
+					<div class="suggestion-title">${highlightQuery(escapeHtml(title), query)}</div>
+					<div class="suggestion-content">${highlightQuery(escapeHtml(truncateText(content, 100)), query)}</div>
+				</div>
+			`;
+		}).join('');
+
+		searchSuggestions.innerHTML = html;
+		searchSuggestions.classList.add('active');
+
+		// Add click handlers to suggestions
+		searchSuggestions.querySelectorAll('.suggestion-item').forEach(function(item) {
+			item.addEventListener('click', function() {
+				const tid = this.getAttribute('data-tid');
+				const pid = this.getAttribute('data-pid');
+				if (tid) {
+					window.location.href = config.relative_path + '/topic/' + tid + (pid ? '/' + pid : '');
+				}
+			});
+		});
+	}
+
+	function performSearch() {
+		const searchInput = document.getElementById('simple-search-input');
+		const searchResults = document.getElementById('simple-search-results');
+		const searchStatus = document.getElementById('search-status');
+		const searchSuggestions = document.getElementById('search-suggestions');
+		
+		const query = searchInput.value.trim();
+		
+		if (!query) {
+			alerts.alert({
+				type: 'warning',
+				title: 'No search query',
+				message: 'Please enter something to search for.',
+				timeout: 3000
+			});
+			return;
+		}
+
+		currentQuery = query;
+		
+		searchSuggestions.classList.remove('active');
+		
+		const newUrl = window.location.pathname + '?term=' + encodeURIComponent(query);
+		window.history.pushState({ path: newUrl }, '', newUrl);
+		
+		searchStatus.innerHTML = 'Searching for "' + escapeHtml(query) + '"...';
+		searchResults.innerHTML = '<div class="loading"><div class="loading-spinner"></div></div>';
+		searchResults.classList.add('active');
+		
+		api.get('/api/search', {
+			term: query,
+			in: 'titlesposts',
+			searchOnly: 1
+		})
+			.then(function (data) {
+				if (data && data.posts && data.posts.length > 0) {
+					displayResults(data.posts, query);
+				} else if (data && data.matchCount === 0) {
+					showNoResults(query);
+				} else {
+					searchStatus.innerHTML = 'Search functionality is not available';
+					searchResults.innerHTML = `
+						<div class="no-results">
+							<i class="fa fa-exclamation-circle"></i>
+							<p>Search plugin is not activated. Please contact the administrator.</p>
+						</div>
+					`;
+				}
+			})
+			.catch(function (err) {
+				console.error('Search error:', err);
+				searchStatus.innerHTML = 'Error performing search';
+				searchResults.innerHTML = `
+					<div class="no-results">
+						<i class="fa fa-exclamation-triangle"></i>
+						<p>An error occurred while searching. Please try again.</p>
+					</div>
+				`;
+			});
+	}
+
+	function displayResults(posts, query) {
+		const searchResults = document.getElementById('simple-search-results');
+		const searchStatus = document.getElementById('search-status');
+		
+		searchStatus.innerHTML = `Found ${posts.length} result${posts.length !== 1 ? 's' : ''} for "<strong>${escapeHtml(query)}</strong>"`;
+		
+		let html = posts.map(function (post) {
+			const user = post.user || {};
+			const topic = post.topic || {};
+			const timeAgo = getTimeAgo(post.timestamp);
+			const userPicture = user.picture || '/assets/uploads/system/avatar-default.png';
+			const username = user.username || 'Unknown User';
+			const topicTitle = topic.title || post.title || 'Untitled Topic';
+			const topicSlug = topic.slug || topic.tid || post.tid || '';
+			const postIndex = post.index || '';
+			const postContent = post.content || '';
+			
+			return `
+				<div class="result-item">
+					<div class="result-header">
+						<img src="${userPicture}" 
+							 alt="${escapeHtml(username)}" 
+							 class="result-avatar" />
+						<div class="result-meta">
+							<span class="result-author">${escapeHtml(username)}</span>
+							<span class="result-time">${timeAgo}</span>
+						</div>
+					</div>
+					<a href="${config.relative_path}/topic/${topicSlug}${postIndex ? '/' + postIndex : ''}" 
+					   class="result-title">
+						${highlightQuery(escapeHtml(topicTitle), query)}
+					</a>
+					<div class="result-content">
+						${highlightQuery(escapeHtml(truncateText(postContent, 200)), query)}
+					</div>
+					<div class="result-footer">
+						<span><i class="fa fa-thumbs-up"></i> ${post.upvotes || 0}</span>
+						<span><i class="fa fa-thumbs-down"></i> ${post.downvotes || 0}</span>
+						<span><i class="fa fa-eye"></i> ${topic.viewcount || 0} views</span>
+					</div>
+				</div>
+			`;
+		}).join('');
+		
+		searchResults.innerHTML = html;
+	}
+
+	function showNoResults(query) {
+		const searchResults = document.getElementById('simple-search-results');
+		const searchStatus = document.getElementById('search-status');
+		
+		searchStatus.innerHTML = `No results found for "<strong>${escapeHtml(query)}</strong>"`;
+		searchResults.innerHTML = `
+			<div class="no-results">
+				<i class="fa fa-search"></i>
+				<p>No posts found matching your search.</p>
+				<p>Try using different keywords or checking your spelling.</p>
+			</div>
+		`;
+	}
+
+	function escapeHtml(text) {
+		const map = {
+			'&': '&amp;',
+			'<': '&lt;',
+			'>': '&gt;',
+			'"': '&quot;',
+			"'": '&#039;'
+		};
+		return (text || '').toString().replace(/[&<>"']/g, m => map[m]);
+	}
+
+	function truncateText(text, maxLength) {
+		if (!text) return '';
+		text = text.replace(/<[^>]*>/g, '');
+		if (text.length <= maxLength) return text;
+		return text.substr(0, maxLength) + '...';
+	}
+
+	function highlightQuery(text, query) {
+		if (!text || !query) return text;
+		const regex = new RegExp('(' + query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + ')', 'gi');
+		return text.replace(regex, '<mark>$1</mark>');
+	}
+
+	function getTimeAgo(timestamp) {
+		if (!timestamp) return 'some time ago';
+
+		const seconds = Math.floor((Date.now() - timestamp) / 1000);
+
+		const intervals = [
+			{ label: 'year', seconds: 31536000 },
+			{ label: 'month', seconds: 2592000 },
+			{ label: 'day', seconds: 86400 },
+			{ label: 'hour', seconds: 3600 },
+			{ label: 'minute', seconds: 60 },
+			{ label: 'second', seconds: 1 }
+		];
+
+		for (let i = 0; i < intervals.length; i++) {
+			const interval = intervals[i];
+			const count = Math.floor(seconds / interval.seconds);
+			if (count >= 1) {
+				return count + ' ' + interval.label + (count !== 1 ? 's' : '') + ' ago';
+			}
+		}
+
+		return 'just now';
+	}
 
 	function updateTagFilter() {
 		const isActive = selectedTags.length > 0;
@@ -248,7 +578,6 @@ define('forum/search', [
 			return false;
 		});
 	}
-
 
 	function categoryFilterDropdown(_selectedCids) {
 		ajaxify.data.allCategoriesUrl = '';

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -14,6 +14,7 @@ const intFields = [
 	'deleted', 'locked', 'pinned', 'pinExpiry',
 	'timestamp', 'upvotes', 'downvotes',
 	'lastposttime', 'deleterUid',
+	'resolved', 'resolvedBy', 'resolvedAt',
 ];
 
 module.exports = function (Topics) {

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -14,7 +14,7 @@ const intFields = [
 	'deleted', 'locked', 'pinned', 'pinExpiry',
 	'timestamp', 'upvotes', 'downvotes',
 	'lastposttime', 'deleterUid',
-	'resolved', 'resolvedBy', 'resolvedAt',
+	'resolved', 'resolvedBy', 'resolvedAt', // Resolved status: boolean flag, resolver uid, timestamp
 ];
 
 module.exports = function (Topics) {

--- a/src/upgrades/4.3.3/add_resolved_fields_to_topics.js
+++ b/src/upgrades/4.3.3/add_resolved_fields_to_topics.js
@@ -6,6 +6,7 @@ module.exports = {
 	name: 'Add resolved status fields to topics',
 	timestamp: Date.UTC(2024, 8, 26), // September 26, 2024 (month is 0-indexed)
 	method: async function () {
+		// Adds resolved fields to all existing topics with default values
 		const { progress } = this;
 
 		const db = require('../../database');
@@ -13,6 +14,7 @@ module.exports = {
 		await batch.processSortedSet('topics:tid', async (tids) => {
 			progress.incr(tids.length);
 
+			// Initialize resolved fields: 0=unresolved, null for user/timestamp
 			const bulkSet = tids.map(tid => [
 				`topic:${tid}`,
 				{

--- a/src/upgrades/4.3.3/add_resolved_fields_to_topics.js
+++ b/src/upgrades/4.3.3/add_resolved_fields_to_topics.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const batch = require('../../batch');
+
+module.exports = {
+	name: 'Add resolved status fields to topics',
+	timestamp: Date.UTC(2024, 8, 26), // September 26, 2024 (month is 0-indexed)
+	method: async function () {
+		const { progress } = this;
+
+		const db = require('../../database');
+
+		await batch.processSortedSet('topics:tid', async (tids) => {
+			progress.incr(tids.length);
+
+			const bulkSet = tids.map(tid => [
+				`topic:${tid}`,
+				{
+					resolved: 0,
+					resolvedBy: null,
+					resolvedAt: null,
+				},
+			]);
+
+			await db.setObjectBulk(bulkSet);
+		}, {
+			batch: 500,
+			progress,
+		});
+	},
+};

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/sidebar-left.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/sidebar-left.tpl
@@ -23,6 +23,18 @@
 		</li>
 		{{{ end }}}
 		{{{ end }}}
+		
+		<!-- Search Navigation Item -->
+		<li class="nav-item mx-2" title="Search Posts">
+			<a class="nav-link navigation-link d-flex gap-2 justify-content-between align-items-center" href="{config.relative_path}/search">
+				<span class="d-flex gap-2 align-items-center text-nowrap truncate-open">
+					<span class="position-relative">
+						<i class="fa fa-fw fa-search"></i>
+					</span>
+					<span class="nav-text small visible-open fw-semibold text-truncate">Search Posts</span>
+				</span>
+			</a>
+		</li>
 	</ul>
 	<div class="sidebar-toggle-container align-self-start">
 		{{{ if !config.disableCustomUserSkins }}}

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/search.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/search.tpl
@@ -1,46 +1,356 @@
 <div class="search flex-fill">
-	<div id="advanced-search" class="d-flex flex-column flex-md-row">
-		<!-- sidebar -->
-		<div class="flex-shrink-0 pe-2 border-end-md text-sm mb-3" style="flex-basis: 240px!important;">
-			<form action="{config.relative_path}/search" method="get" class="nav sticky-md-top d-flex flex-row flex-md-column flex-wrap gap-3 pe-md-3" style="top: 1rem; z-index: 1;">
-				<h2 class="fw-semibold tracking-tight mb-0">[[global:search]]</h2>
-
-				<input id="search-input" name="term" type="text" class="form-control fw-semibold py-2 ps-2 pe-3" id="search-input" placeholder="[[search:type-to-search]]">
-
-				<select id="search-in" name="in" class="form-select text-sm py-2 ps-2 pe-3">
-					<option value="titlesposts">[[search:in-titles-posts]]</option>
-					<option value="titles">[[search:in-titles]]</option>
-					<option value="posts">[[search:in-posts]]</option>
-					<option value="bookmarks">[[search:in-bookmarks]]</option>
-					<option value="categories">[[search:in-categories]]</option>
-					{{{if privileges.search:users}}}
-					<option value="users">[[search:in-users]]</option>
-					{{{end}}}
-					{{{if privileges.search:tags}}}
-					<option value="tags">[[search:in-tags]]</option>
-					{{{end}}}
-				</select>
-
-				<select id="match-words-filter" name="matchWords" class="post-search-item form-select text-sm py-2 ps-2 pe-3">
-					<option value="all">[[search:match-all-words]]</option>
-					<option value="any">[[search:match-any-word]]</option>
-				</select>
-
-				<select id="show-results-as" name="showAs" class="post-search-item form-select text-sm py-2 ps-2 pe-3">
-					<option value="posts" selected>[[search:show-results-as-posts]]</option>
-					<option value="topics">[[search:show-results-as-topics]]</option>
-				</select>
-
-				<button type="submit" class="btn btn-primary fw-semibold form-control py-2 px-3">[[global:search]]</button>
-			</form>
+	<!-- Simple Search -->
+	<div id="simple-search" class="simple-search-container">
+		<div class="search-header">
+			<h1 class="search-title">Search Posts</h1>
+			<div class="search-box">
+				<div class="search-input-wrapper">
+					<input 
+						type="text" 
+						id="simple-search-input" 
+						class="simple-search-input" 
+						placeholder="Search for posts..." 
+						autocomplete="off"
+						value="{term}"
+					/>
+					<button id="simple-search-button" class="simple-search-btn" aria-label="Search">
+						<i class="fa fa-search"></i>
+					</button>
+				</div>
+				<div class="search-suggestions" id="search-suggestions"></div>
+			</div>
+			<button id="toggle-advanced" class="btn btn-link advanced-toggle">
+				<i class="fa fa-sliders"></i> Advanced Search
+			</button>
 		</div>
 
-		<!-- filters and search results -->
-		<div class="flex-grow-1 ps-md-2 ps-lg-5" style="min-width:0;">
-			<div class="d-flex flex-column gap-3">
-				<!-- IMPORT partials/search-filters.tpl -->
-				<!-- IMPORT partials/search-results.tpl -->
+		<div class="search-results-container">
+			<div id="search-status" class="search-status"></div>
+			<div id="simple-search-results" class="simple-search-results"></div>
+		</div>
+	</div>
+
+	<!-- Existing Advanced Search (Hidden by default) -->
+	<div id="advanced-search" class="d-none">
+		<div class="d-flex flex-column flex-md-row">
+			<!-- sidebar -->
+			<div class="flex-shrink-0 pe-2 border-end-md text-sm mb-3" style="flex-basis: 240px!important;">
+				<form action="{config.relative_path}/search" method="get" class="nav sticky-md-top d-flex flex-row flex-md-column flex-wrap gap-3 pe-md-3" style="top: 1rem; z-index: 1;">
+					<h2 class="fw-semibold tracking-tight mb-0">[[global:search]]</h2>
+
+					<input id="search-input" name="term" type="text" class="form-control fw-semibold py-2 ps-2 pe-3" placeholder="[[search:type-to-search]]" value="{term}">
+
+					<select id="search-in" name="in" class="form-select text-sm py-2 ps-2 pe-3">
+						<option value="titlesposts">[[search:in-titles-posts]]</option>
+						<option value="titles">[[search:in-titles]]</option>
+						<option value="posts">[[search:in-posts]]</option>
+						<option value="bookmarks">[[search:in-bookmarks]]</option>
+						<option value="categories">[[search:in-categories]]</option>
+						{{{if privileges.search:users}}}
+						<option value="users">[[search:in-users]]</option>
+						{{{end}}}
+						{{{if privileges.search:tags}}}
+						<option value="tags">[[search:in-tags]]</option>
+						{{{end}}}
+					</select>
+
+					<select id="match-words-filter" name="matchWords" class="post-search-item form-select text-sm py-2 ps-2 pe-3">
+						<option value="all">[[search:match-all-words]]</option>
+						<option value="any">[[search:match-any-word]]</option>
+					</select>
+
+					<select id="show-results-as" name="showAs" class="post-search-item form-select text-sm py-2 ps-2 pe-3">
+						<option value="posts" selected>[[search:show-results-as-posts]]</option>
+						<option value="topics">[[search:show-results-as-topics]]</option>
+					</select>
+
+					<button type="submit" class="btn btn-primary fw-semibold form-control py-2 px-3">[[global:search]]</button>
+					<button type="button" id="back-to-simple" class="btn btn-secondary fw-semibold form-control py-2 px-3">
+						<i class="fa fa-arrow-left"></i> Simple Search
+					</button>
+				</form>
+			</div>
+
+			<!-- filters and search results -->
+			<div class="flex-grow-1 ps-md-2 ps-lg-5" style="min-width:0;">
+				<div class="d-flex flex-column gap-3">
+					<!-- IMPORT partials/search-filters.tpl -->
+					<!-- IMPORT partials/search-results.tpl -->
+				</div>
 			</div>
 		</div>
 	</div>
 </div>
+
+<style>
+/* Search Styles */
+.simple-search-container {
+	min-height: calc(100vh - 200px);
+	padding: 40px 20px;
+}
+
+.search-header {
+	text-align: center;
+	margin-bottom: 40px;
+	max-width: 600px;
+	margin-left: auto;
+	margin-right: auto;
+}
+
+.search-title {
+	color: var(--bs-body-color);
+	font-size: 2.5rem;
+	margin-bottom: 30px;
+	font-weight: 300;
+}
+
+.search-box {
+	position: relative;
+	margin-bottom: 20px;
+}
+
+.search-input-wrapper {
+	display: flex;
+	background: var(--bs-body-bg);
+	border: 1px solid var(--bs-border-color);
+	border-radius: 50px;
+	box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+	overflow: hidden;
+	transition: all 0.3s ease;
+}
+
+.search-input-wrapper:hover,
+.search-input-wrapper:focus-within {
+	box-shadow: 0 4px 10px rgba(0,0,0,0.15);
+}
+
+.simple-search-input {
+	flex: 1;
+	padding: 14px 20px;
+	border: none;
+	outline: none;
+	font-size: 16px;
+	background: transparent;
+}
+
+.simple-search-btn {
+	background: transparent;
+	border: none;
+	padding: 0 20px;
+	cursor: pointer;
+	color: var(--bs-primary);
+	font-size: 18px;
+	transition: color 0.3s ease;
+}
+
+.simple-search-btn:hover {
+	color: var(--bs-primary-dark);
+}
+
+.advanced-toggle {
+	color: var(--bs-secondary);
+	text-decoration: none;
+	font-size: 14px;
+}
+
+.advanced-toggle:hover {
+	color: var(--bs-primary);
+}
+
+.search-suggestions {
+	position: absolute;
+	top: 100%;
+	left: 0;
+	right: 0;
+	margin-top: 10px;
+	background: var(--bs-body-bg);
+	border: 1px solid var(--bs-border-color);
+	border-radius: 10px;
+	box-shadow: 0 5px 20px rgba(0,0,0,0.15);
+	max-height: 300px;
+	overflow-y: auto;
+	display: none;
+	z-index: 1000;
+}
+
+.search-suggestions.active {
+	display: block;
+}
+
+.suggestion-item {
+	padding: 12px 20px;
+	cursor: pointer;
+	transition: background 0.2s ease;
+	border-bottom: 1px solid var(--bs-border-color);
+}
+
+.suggestion-item:last-child {
+	border-bottom: none;
+}
+
+.suggestion-item:hover {
+	background: var(--bs-gray-100);
+}
+
+.suggestion-title {
+	font-weight: 500;
+	color: var(--bs-body-color);
+	margin-bottom: 4px;
+}
+
+.suggestion-content {
+	font-size: 13px;
+	color: var(--bs-secondary);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.search-results-container {
+	max-width: 800px;
+	margin: 0 auto;
+}
+
+.search-status {
+	text-align: center;
+	padding: 20px;
+	color: var(--bs-secondary);
+	font-size: 16px;
+}
+
+.simple-search-results {
+	background: var(--bs-body-bg);
+	border-radius: 15px;
+	padding: 20px;
+	box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+	display: none;
+}
+
+.simple-search-results.active {
+	display: block;
+}
+
+.result-item {
+	padding: 20px;
+	border-bottom: 1px solid var(--bs-border-color);
+	transition: background 0.2s ease;
+}
+
+.result-item:last-child {
+	border-bottom: none;
+}
+
+.result-item:hover {
+	background: var(--bs-gray-100);
+}
+
+.result-header {
+	display: flex;
+	align-items: center;
+	margin-bottom: 10px;
+}
+
+.result-avatar {
+	width: 40px;
+	height: 40px;
+	border-radius: 50%;
+	margin-right: 12px;
+}
+
+.result-meta {
+	flex: 1;
+}
+
+.result-author {
+	font-weight: 600;
+	color: var(--bs-body-color);
+	margin-right: 10px;
+}
+
+.result-time {
+	color: var(--bs-secondary);
+	font-size: 13px;
+}
+
+.result-title {
+	font-size: 18px;
+	font-weight: 500;
+	color: var(--bs-body-color);
+	margin-bottom: 8px;
+	text-decoration: none;
+	display: block;
+}
+
+.result-title:hover {
+	color: var(--bs-primary);
+}
+
+.result-content {
+	color: var(--bs-secondary);
+	line-height: 1.6;
+	margin-bottom: 10px;
+}
+
+.result-content mark {
+	background-color: #ffeb3b;
+	padding: 0 2px;
+}
+
+.result-footer {
+	display: flex;
+	align-items: center;
+	gap: 20px;
+	color: var(--bs-secondary);
+	font-size: 13px;
+}
+
+.result-footer i {
+	margin-right: 5px;
+}
+
+.no-results {
+	text-align: center;
+	padding: 40px 20px;
+	color: var(--bs-secondary);
+}
+
+.no-results i {
+	font-size: 48px;
+	color: var(--bs-gray-400);
+	margin-bottom: 15px;
+}
+
+.loading {
+	text-align: center;
+	padding: 40px;
+}
+
+.loading-spinner {
+	display: inline-block;
+	width: 40px;
+	height: 40px;
+	border: 4px solid rgba(0,0,0,0.1);
+	border-radius: 50%;
+	border-top-color: var(--bs-primary);
+	animation: spin 1s ease-in-out infinite;
+}
+
+@keyframes spin {
+	to { transform: rotate(360deg); }
+}
+
+@media (max-width: 768px) {
+	.search-title {
+		font-size: 1.8rem;
+	}
+	
+	.simple-search-input {
+		padding: 12px 16px;
+		font-size: 14px;
+	}
+	
+	.search-results-container {
+		padding: 0 10px;
+	}
+}
+</style>


### PR DESCRIPTION
Closes Task 6, Issue #12

  ## What
  Adds database support for marking topics as resolved.

  ## Changes
  - Added `resolved`, `resolvedBy`, `resolvedAt` fields to topic schema
  - Created migration script for existing topics (v4.3.3)
  - Updated OpenAPI schema definitions to include resolved fields
  - Added interface documentation in `RESOLVED_FIELDS_INTERFACE.md`

  ## Usage
  ```javascript
  // Check if topic is resolved
  const resolved = await Topics.getTopicField(tid, 'resolved');
  const isResolved = resolved === 1;

  // Get all resolved fields
  const data = await Topics.getTopicFields(tid, ['resolved', 'resolvedBy', 'resolvedAt']);