### PR TITLE
Fix Search Implementation

### DIFF
--- a/public/src/client/search.js
+++ b/public/src/client/search.js
@@ -89,8 +89,8 @@ define('forum/search', [
 
 		searchFilters = getSearchDataFromDOM();
 
-		const urlParams = new URLSearchParams(window.location.search);
-		const queryParam = urlParams.get('term') || urlParams.get('query');
+		const searchParams = new URLSearchParams(window.location.search);
+		const queryParam = searchParams.get('term') || searchParams.get('query');
 		if (queryParam) {
 			const simpleInput = document.getElementById('simple-search-input');
 			if (simpleInput) {
@@ -417,7 +417,7 @@ define('forum/search', [
 	function updateSearchResults(searchData) {
 		// Build query string
 		const queryString = Object.entries(searchData)
-			.filter(([key, value]) => value !== undefined && value !== null && value !== '')
+			.filter(([, value]) => value !== undefined && value !== null && value !== '')
 			.map(([key, value]) => {
 				if (Array.isArray(value)) {
 					return value.map(v => `${encodeURIComponent(key)}=${encodeURIComponent(v)}`).join('&');

--- a/src/controllers/search.js
+++ b/src/controllers/search.js
@@ -19,7 +19,7 @@ const helpers = require('./helpers');
 
 const searchController = module.exports;
 
-searchController.search = async function (req, res, next) {
+searchController.search = async function (req, res) {
 	const page = Math.max(1, parseInt(req.query.page, 10)) || 1;
 
 	const searchOnly = parseInt(req.query.searchOnly, 10) === 1;

--- a/src/controllers/search.js
+++ b/src/controllers/search.js
@@ -20,9 +20,6 @@ const helpers = require('./helpers');
 const searchController = module.exports;
 
 searchController.search = async function (req, res, next) {
-	if (!plugins.hooks.hasListeners('filter:search.query')) {
-		return next();
-	}
 	const page = Math.max(1, parseInt(req.query.page, 10)) || 1;
 
 	const searchOnly = parseInt(req.query.searchOnly, 10) === 1;

--- a/src/search.js
+++ b/src/search.js
@@ -98,7 +98,7 @@ async function searchInContent(data) {
 				await batch.processSortedSet('posts:pid', async (pids) => {
 					const postData = await posts.getPostsFields(pids, ['pid', 'content', 'tid', 'uid', 'cid', 'deleted']);
 
-					const matchingPids = postData.filter(post => {
+					const matchingPids = postData.filter((post) => {
 						if (!post || !post.content || post.deleted) {
 							return false;
 						}
@@ -117,9 +117,8 @@ async function searchInContent(data) {
 
 						if (matchWords === 'all') {
 							return tokens.every(token => content.includes(token));
-						} else {
-							return tokens.some(token => content.includes(token));
 						}
+						return tokens.some(token => content.includes(token));
 					}).map(post => post.pid);
 
 					allPids.push(...matchingPids);
@@ -137,7 +136,7 @@ async function searchInContent(data) {
 				await batch.processSortedSet('topics:tid', async (tids) => {
 					const topicData = await topics.getTopicsFields(tids, ['tid', 'title', 'cid', 'uid', 'deleted']);
 
-					const matchingTids = topicData.filter(topic => {
+					const matchingTids = topicData.filter((topic) => {
 						if (!topic || !topic.title || topic.deleted) {
 							return false;
 						}
@@ -156,9 +155,8 @@ async function searchInContent(data) {
 
 						if (matchWords === 'all') {
 							return tokens.every(token => title.includes(token));
-						} else {
-							return tokens.some(token => title.includes(token));
 						}
+						return tokens.some(token => title.includes(token));
 					}).map(topic => topic.tid);
 
 					allTids.push(...matchingTids);


### PR DESCRIPTION
  Changes Made:
  - Fixed 404 error on /search route when no search plugin is installed
  - Implemented basic database search functionality as fallback when no search plugin is present
  - Added search support for posts, titles, categories, users, and tags
  - Fixed advanced search interface switching back to simple search on form submission

  Technical Details:
  - Removed plugin dependency check in src/controllers/search.js that was causing 404 errors
  - Added fallback search implementation in src/search.js that queries the database directly
  - Modified public/src/client/search.js to use AJAX updates instead of page navigation for advanced search
  - Maintains all advanced search filters (categories, users, tags, time range, reply count, sorting)

  Result:
  Search now works out-of-the-box without requiring a search plugin installation, while still supporting
  plugin-based search when available.