### PR TITLE
Added mark resolved/unresolved indicator and filter for topics (Task 9, Issue #17)

### DIFF
--- a/public/language/en-US/topic.json
+++ b/public/language/en-US/topic.json
@@ -34,6 +34,8 @@
     "tools": "Tools",
     "locked": "Locked",
     "resolved": "Resolved",
+    "resolved-topics": "Resolved Topics",
+    "unresolved-topics": "Unresolved Topics",
     "mark-resolved": "Mark resolved",
     "mark-unresolved": "Mark unresolved",
     "pinned": "Pinned",

--- a/public/src/modules/topicList.js
+++ b/public/src/modules/topicList.js
@@ -83,11 +83,17 @@ define('topicList', [
 		TopicList.removeListeners();
 		socket.on('event:new_topic', onNewTopic);
 		socket.on('event:new_post', onNewPost);
+		// Listen for topic resolved/unresolved events to update UI dynamically
+		socket.on('event:topic_resolved', onTopicResolved);
+		socket.on('event:topic_unresolved', onTopicUnresolved);
 	};
 
 	TopicList.removeListeners = function () {
 		socket.removeListener('event:new_topic', onNewTopic);
 		socket.removeListener('event:new_post', onNewPost);
+		// Remove resolved/unresolved event listeners
+		socket.removeListener('event:topic_resolved', onTopicResolved);
+		socket.removeListener('event:topic_unresolved', onTopicUnresolved);
 	};
 
 	function onNewTopic(data) {

--- a/public/src/modules/topicList.js
+++ b/public/src/modules/topicList.js
@@ -159,6 +159,30 @@ define('topicList', [
 		}
 	}
 
+	// Handle topic resolved event - shows resolved badge on topic in list
+	function onTopicResolved(data) {
+		if (!data || !data.tid) {
+			return;
+		}
+		const topicEl = topicListEl.find('[component="category/topic"][data-tid="' + data.tid + '"]');
+		if (topicEl.length) {
+			// Show the resolved badge
+			topicEl.find('[component="topic/resolved"]').removeClass('hidden');
+		}
+	}
+
+	// Handle topic unresolved event - hides resolved badge on topic in list
+	function onTopicUnresolved(data) {
+		if (!data || !data.tid) {
+			return;
+		}
+		const topicEl = topicListEl.find('[component="category/topic"][data-tid="' + data.tid + '"]');
+		if (topicEl.length) {
+			// Hide the resolved badge
+			topicEl.find('[component="topic/resolved"]').addClass('hidden');
+		}
+	}
+
 	TopicList.loadMoreTopics = function (direction) {
 		if (!topicListEl.length || !topicListEl.children().length) {
 			return;

--- a/src/categories/topics.js
+++ b/src/categories/topics.js
@@ -18,6 +18,18 @@ module.exports = function (Categories) {
 		let topicsData = await topics.getTopicsByTids(tids, data.uid);
 		topicsData = await user.blocks.filter(data.uid, topicsData);
 
+		// Filter topics by resolved status if filter is 'resolved' or 'unresolved'
+		if (data.filter === 'resolved' || data.filter === 'unresolved') {
+			topicsData = topicsData.filter((topic) => {
+				if (data.filter === 'resolved') {
+					return topic && topic.resolved === 1;
+				} else if (data.filter === 'unresolved') {
+					return topic && topic.resolved !== 1;
+				}
+				return true;
+			});
+		}
+
 		if (!topicsData.length) {
 			return { topics: [], uid: data.uid };
 		}

--- a/src/controllers/category.js
+++ b/src/controllers/category.js
@@ -91,6 +91,8 @@ categoryController.get = async function (req, res, next) {
 	const stop = start + userSettings.topicsPerPage - 1;
 
 	const sort = validSorts.includes(req.query.sort) ? req.query.sort : userSettings.categoryTopicSort;
+	// Get filter parameter from query string (for resolved/unresolved filtering)
+	const filter = req.query.filter || '';
 
 	const categoryData = await categories.getCategoryById({
 		uid: req.uid,
@@ -102,6 +104,7 @@ categoryController.get = async function (req, res, next) {
 		query: req.query,
 		tag: req.query.tag,
 		targetUid: targetUid,
+		filter: filter, // Pass filter to enable resolved/unresolved filtering
 	});
 	if (!categoryData) {
 		return next();
@@ -150,6 +153,11 @@ categoryController.get = async function (req, res, next) {
 	categoryData.selectedTag = tagData.selectedTag;
 	categoryData.selectedTags = tagData.selectedTags;
 	categoryData.sortOptionLabel = `[[topic:${validator.escape(String(sort)).replace(/_/g, '-')}]]`;
+
+	// Add filter options for resolved/unresolved topics
+	const baseUrl = `category/${categoryData.slug}`;
+	categoryData.filters = helpers.buildFilters(baseUrl, filter, req.query);
+	categoryData.selectedFilter = categoryData.filters.find(f => f && f.selected);
 
 	if (!meta.config['feeds:disableRSS']) {
 		categoryData.rssFeedUrl = `${url}/category/${categoryData.cid}.rss`;

--- a/src/controllers/helpers.js
+++ b/src/controllers/helpers.js
@@ -70,6 +70,7 @@ helpers.addLinkTags = function (params) {
 	});
 };
 
+// Build filter options for topic filtering - includes resolved/unresolved filter
 helpers.buildFilters = function (url, filter, query) {
 	return [{
 		name: '[[unread:all-topics]]',
@@ -95,6 +96,20 @@ helpers.buildFilters = function (url, filter, query) {
 		selected: filter === 'unreplied',
 		filter: 'unreplied',
 		icon: 'fa-reply',
+	}, {
+		// Filter to show only resolved topics
+		name: '[[topic:resolved-topics]]',
+		url: url + helpers.buildQueryString(query, 'filter', 'resolved'),
+		selected: filter === 'resolved',
+		filter: 'resolved',
+		icon: 'fa-check-circle',
+	}, {
+		// Filter to show only unresolved topics
+		name: '[[topic:unresolved-topics]]',
+		url: url + helpers.buildQueryString(query, 'filter', 'unresolved'),
+		selected: filter === 'unresolved',
+		filter: 'unresolved',
+		icon: 'fa-circle-o',
 	}];
 };
 

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic-list-bar.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic-list-bar.tpl
@@ -6,6 +6,8 @@
 				<!-- IMPORT partials/category/watch.tpl -->
 				<!-- IMPORT partials/tags/filter-dropdown-left.tpl -->
 				<!-- IMPORT partials/category/sort.tpl -->
+				<!-- Add filter dropdown for resolved/unresolved topics in category view -->
+				<!-- IMPORT partials/topic-filters.tpl -->
 				{{{ end }}}
 				{{{ if (template.popular || template.top)}}}
 				<!-- IMPORT partials/topic-terms.tpl -->

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl
@@ -24,6 +24,11 @@
 					<a class="text-reset" href="{{{ if topics.noAnchor }}}#{{{ else }}}{config.relative_path}/topic/{./slug}{{{ if ./bookmark }}}/{./bookmark}{{{ end }}}{{{ end }}}">{./title}</a>
 				</h3>
 				<span component="topic/labels" class="d-flex flex-wrap gap-1 w-100">
+					<!-- Resolved topic indicator - displays green checkmark for resolved topics -->
+					<span component="topic/resolved" class="badge border border-success text-success {{{ if !./resolved }}}hidden{{{ end }}}">
+						<i class="fa fa-check-circle"></i>
+						<span>[[topic:resolved]]</span>
+					</span>
 					<span component="topic/watched" class="badge border border-gray-300 text-body {{{ if !./followed }}}hidden{{{ end }}}">
 						<i class="fa fa-bell-o"></i>
 						<span>[[topic:watching]]</span>


### PR DESCRIPTION
_**Resolved Issue #17**_ 

Task:
---
Adding frontend resolve indicator to show if a topic is being resolved and filtering mechanism to view resolved/unresolved topics. 

Changes:
---
- Visual Indicators: Displays fa-check-circle icon on resolved topics in all topic lists
- Component selector: [component="topic/resolved"] with Bootstrap success styling
- Filter options: "Resolved Topics" and "Unresolved Topics" added to topic filter dropdown
- Real-time Updates: Socket.io events ( event:topic_resolved and event:topic_unresolved listeners)
- Event handlers: onTopicResolved() and onTopicUnresolved() functions
- Filter UI: templates/partials/topic-list-bar.tpl imports topic filters for category view
- Documentation: Inline comments, code validation

Acceptance Criteria Accomplished:
---
- Green checkmark icon on resolved topics
- "Resolved" badge in topic lists
- Filter option to show/hide resolved topics

**_Close Issue #17_** 