### PR TITLE
Auto-enabled user-created categories plugin - continued

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -104,6 +104,7 @@
         "nodebb-plugin-markdown": "13.2.1",
         "nodebb-plugin-mentions": "4.7.6",
         "nodebb-plugin-spam-be-gone": "2.3.2",
+        "nodebb-plugin-user-public-categories": "file:nodebb-plugin-user-public-categories",
         "nodebb-plugin-web-push": "0.7.4",
         "nodebb-rewards-essentials": "1.0.2",
         "nodebb-theme-harmony": "file:vendor/nodebb-theme-harmony-2.1.15",


### PR DESCRIPTION
Adds nodebb-plugin-user-public-categories to install/package.json so the plugin is automatically installed for all team members when they run npm install. Continuation of PR #39, which was not really fixed. Resolves #10.