### PR TITLE
Fixed unresolved topic filter bug (Issue #17 bug fix)

### DIFF
--- a/src/api/categories.js
+++ b/src/api/categories.js
@@ -150,6 +150,7 @@ categoriesAPI.getTopics = async (caller, data) => {
 		query: data.query,
 		tag: data.query.tag,
 		targetUid,
+		filter: data.query.filter,
 	});
 	categories.modifyTopicsByPrivilege(result.topics, userPrivileges);
 

--- a/src/categories/topics.js
+++ b/src/categories/topics.js
@@ -19,11 +19,12 @@ module.exports = function (Categories) {
 		topicsData = await user.blocks.filter(data.uid, topicsData);
 
 		// Filter topics by resolved status if filter is 'resolved' or 'unresolved'
-		if (data.filter === 'resolved' || data.filter === 'unresolved') {
+		const filter = results.filter || data.filter;
+		if (filter === 'resolved' || filter === 'unresolved') {
 			topicsData = topicsData.filter((topic) => {
-				if (data.filter === 'resolved') {
+				if (filter === 'resolved') {
 					return topic && topic.resolved === 1;
-				} else if (data.filter === 'unresolved') {
+				} else if (filter === 'unresolved') {
 					return topic && topic.resolved !== 1;
 				}
 				return true;


### PR DESCRIPTION
## Summary
Fixes bug where filtering by "unresolved" topics showed both resolved and unresolved topics.

## Changes
- **API endpoint fix**: Added missing `filter` parameter to `getCategoryTopics` call in `src/api/categories.js`
- **Filter handling**: Updated `src/categories/topics.js` to properly check filter from plugin hook results
- **Root cause**: Page makes two calls to get category topics - one from controller (correct) and one from API endpoint (was missing filter parameter)

## Bug Details
When filtering by "unresolved" on category pages:
- First call from category controller properly passed filter parameter
- Second call from API endpoint (`/api/category/{cid}`) did not pass filter parameter
- Second API call overrode the first, showing all topics instead of just unresolved

## Test Plan
1. Navigate to a category page with both resolved and unresolved topics
2. Click "Unresolved Topics" filter
3. Verify URL shows `?filter=unresolved`
4. Verify only unresolved topics (without green checkmark) are displayed
5. Verify resolved topics (with green checkmark) are hidden

Fixes filtering issue in #17